### PR TITLE
Fix git safe.directory error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,3 +17,5 @@ COPY requirements.txt /app
 RUN --mount=type=cache,target=/root/.cache pip install --upgrade pip && pip install -r requirements.txt
 
 RUN playwright install chromium
+
+RUN git config --system --replace-all safe.directory '*'


### PR DESCRIPTION
Attempt to fix "dubious ownership" issues during deployment:

```sh
err: fatal: detected dubious ownership in repository at '/var/www/staging'
err: To add an exception for this directory, call:
err: 	git config --global --add safe.directory /var/www/staging
```